### PR TITLE
update postgres 9.6 to 9.6.3

### DIFF
--- a/version/postgres_9_6_3.sh
+++ b/version/postgres_9_6_3.sh
@@ -3,17 +3,14 @@
 
 sudo apt-get install -y wget ca-certificates
 
-echo "================= Installing Postgres 9.6 ==================="
+echo "================= Installing Postgres 9.6.3 ==================="
 sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
 wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
 sudo apt-get update
 sudo apt-get install -y postgresql-9.6 postgresql-server-dev-9.6
 sudo apt-get install postgis
 
-# Fix bug https://github.com/docker/docker/issues/783
-# which prevents postgresql from staring when using aufs
-# This workaround proposed in the comment to the issue: https://github.com/docker/docker/issues/783#issuecomment-56013588
-# I've test this on my own builds
+
 mkdir /etc/ssl/private-copy
 mv /etc/ssl/private/* /etc/ssl/private-copy/
 rm -r /etc/ssl/private


### PR DESCRIPTION
fixes https://github.com/dry-dock/u14all/issues/45

![selection_006](https://user-images.githubusercontent.com/22500327/28067151-acd1eb48-665d-11e7-9d8f-8c086e6edde3.png)

verified on local system by starting, stopping  postgres and the version