### PR TITLE
sqlite only use apt-get for installation

### DIFF
--- a/version/sqllite_3_21_0.sh
+++ b/version/sqllite_3_21_0.sh
@@ -6,8 +6,3 @@ echo "================= Installing SQLite $SQLITE_VERSION ==================="
 sudo add-apt-repository ppa:jonathonf/backports
 sudo apt-get update && sudo apt-get install sqlite3="$SQLITE_VERSION"*
 
-pushd /tmp
-  wget https://www.sqlite.org/2017/sqlite-tools-linux-x86-3210000.zip
-  unzip -u sqlite-tools-linux-x86-3210000.zip
-  cp -r sqlite-tools-linux-x86-3210000/. /usr/bin
-  rm -rf sqlite-tools-linux-x86-3210000*


### PR DESCRIPTION
https://github.com/dry-dock/u14all/issues/116

sqlite binary is getting overwritten by tools, we should skip this and document steps to install sqlite-tools